### PR TITLE
Update Fabric, Crashlytics, Answer Spec files to support latest release

### DIFF
--- a/Carthage/Answers.json
+++ b/Carthage/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.3.7": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.7/com.twitter.answers.ios-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.6/com.twitter.answers.ios-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.5/com.twitter.answers.ios-default.zip",
   "1.3.4": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.4/com.twitter.answers.ios-default.zip"

--- a/Carthage/Crashlytics.json
+++ b/Carthage/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.2": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.2/com.twitter.crashlytics.ios-default.zip",
   "3.10.1": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.1/com.twitter.crashlytics.ios-default.zip",
   "3.10.0": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.0/com.twitter.crashlytics.ios-default.zip",
   "3.9.3": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.9.3/com.twitter.crashlytics.ios-default.zip",

--- a/Carthage/Fabric.json
+++ b/Carthage/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.7": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.7/io.fabric.sdk.ios-default.zip",
   "1.7.6": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.6/io.fabric.sdk.ios-default.zip",
   "1.7.5": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.5/io.fabric.sdk.ios-default.zip",
   "1.7.2": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.2/io.fabric.sdk.ios-default.zip",

--- a/Carthage/macOS/Answers.json
+++ b/Carthage/macOS/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.3.7": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.7/com.twitter.answers.mac-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.6/com.twitter.answers.mac-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.5/com.twitter.answers.mac-default.zip",
   "1.3.4": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.4/com.twitter.answers.mac-default.zip"

--- a/Carthage/macOS/Crashlytics.json
+++ b/Carthage/macOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.2": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.2/com.twitter.crashlytics.mac-default.zip",
   "3.10.1": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.1/com.twitter.crashlytics.mac-default.zip",
   "3.10.0": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.0/com.twitter.crashlytics.mac-default.zip",
   "3.9.3": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.9.3/com.twitter.crashlytics.mac-default.zip",

--- a/Carthage/macOS/Fabric.json
+++ b/Carthage/macOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.7": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.7/io.fabric.sdk.mac-default.zip",
   "1.7.6": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.6/io.fabric.sdk.mac-default.zip",
   "1.7.5": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.5/io.fabric.sdk.mac-default.zip",
   "1.7.2": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.2/io.fabric.sdk.mac-default.zip",

--- a/Carthage/tvOS/Answers.json
+++ b/Carthage/tvOS/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.3.7": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.7/com.twitter.answers.tvos-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.6/com.twitter.answers.tvos-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.5/com.twitter.answers.tvos-default.zip",
   "1.3.4": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.4/com.twitter.answers.tvos-default.zip"

--- a/Carthage/tvOS/Crashlytics.json
+++ b/Carthage/tvOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.2": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.2/com.twitter.crashlytics.tvos-default.zip",
   "3.10.1": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.1/com.twitter.crashlytics.tvos-default.zip",
   "3.10.0": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.0/com.twitter.crashlytics.tvos-default.zip",
   "3.9.3": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.9.3/com.twitter.crashlytics.tvos-default.zip",

--- a/Carthage/tvOS/Fabric.json
+++ b/Carthage/tvOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.7": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.7/io.fabric.sdk.tvos-default.zip",
   "1.7.6": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.6/io.fabric.sdk.tvos-default.zip",
   "1.7.5": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.5/io.fabric.sdk.tvos-default.zip",
   "1.7.2": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.2/io.fabric.sdk.tvos-default.zip",


### PR DESCRIPTION
Update Fabric, Crashlytics, Answer Spec files to support latest release

All updated for iOS / tvOs / macOS
Fabric 1.7.7
Answers 1.3.7
Crashlytics 3.10.2