### PR TITLE
Update Crashlytics.json

### DIFF
--- a/Carthage/Crashlytics.json
+++ b/Carthage/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.3": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.3/com.twitter.crashlytics.ios-default.zip",
   "3.10.2": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.2/com.twitter.crashlytics.ios-default.zip",
   "3.10.1": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.1/com.twitter.crashlytics.ios-default.zip",
   "3.10.0": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.0/com.twitter.crashlytics.ios-default.zip",


### PR DESCRIPTION
New version for *Crashlytics* -> https://fabric.io/kits/ios/crashlytics/update
> **3.10.3 June 27, 2018**
> Fixed a bug that could cause a crash when writing to disk while unlocking a device with data protection.