### PR TITLE
Add Crashlytics 3.10.7

### DIFF
--- a/Carthage/iOS/Crashlytics.json
+++ b/Carthage/iOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.5/com.twitter.crashlytics.ios-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.4/com.twitter.crashlytics.ios-default.zip",
   "3.10.3": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.3/com.twitter.crashlytics.ios-default.zip",

--- a/Carthage/macOS/Crashlytics.json
+++ b/Carthage/macOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.7": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.7/com.twitter.crashlytics.mac-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.5/com.twitter.crashlytics.mac-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.4/com.twitter.crashlytics.mac-default.zip",
   "3.10.3": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.3/com.twitter.crashlytics.mac-default.zip",

--- a/Carthage/tvOS/Crashlytics.json
+++ b/Carthage/tvOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.7": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.7/com.twitter.crashlytics.tvos-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.5/com.twitter.crashlytics.tvos-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.4/com.twitter.crashlytics.tvos-default.zip",
   "3.10.3": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.3/com.twitter.crashlytics.tvos-default.zip",


### PR DESCRIPTION
Updates the Crashlytics entry to the current version, `3.10.7`.