### PR TITLE
Added Crashlytics 3.10.8 and Fabric 1.7.12

### DIFF
--- a/Carthage/iOS/Crashlytics.json
+++ b/Carthage/iOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.8": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.8/com.twitter.crashlytics.ios-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.5/com.twitter.crashlytics.ios-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.4/com.twitter.crashlytics.ios-default.zip",

--- a/Carthage/iOS/Fabric.json
+++ b/Carthage/iOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.12": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.12/io.fabric.sdk.ios-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.11/io.fabric.sdk.ios-default.zip",
   "1.7.9": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.9/io.fabric.sdk.ios-default.zip",
   "1.7.8": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.8/io.fabric.sdk.ios-default.zip",

--- a/Carthage/macOS/Crashlytics.json
+++ b/Carthage/macOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.8": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.8/com.twitter.crashlytics.mac-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.7/com.twitter.crashlytics.mac-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.5/com.twitter.crashlytics.mac-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.4/com.twitter.crashlytics.mac-default.zip",

--- a/Carthage/macOS/Fabric.json
+++ b/Carthage/macOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.12": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.12/io.fabric.sdk.mac-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.11/io.fabric.sdk.mac-default.zip",
   "1.7.9": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.9/io.fabric.sdk.mac-default.zip",
   "1.7.8": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.8/io.fabric.sdk.mac-default.zip",

--- a/Carthage/tvOS/Crashlytics.json
+++ b/Carthage/tvOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.10.8": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.8/com.twitter.crashlytics.tvos-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.7/com.twitter.crashlytics.tvos-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.5/com.twitter.crashlytics.tvos-default.zip",
   "3.10.4": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.4/com.twitter.crashlytics.tvos-default.zip",

--- a/Carthage/tvOS/Fabric.json
+++ b/Carthage/tvOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.7.12": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.12/io.fabric.sdk.tvos-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.11/io.fabric.sdk.tvos-default.zip",
   "1.7.9": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.9/io.fabric.sdk.tvos-default.zip",
   "1.7.8": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.8/io.fabric.sdk.tvos-default.zip",


### PR DESCRIPTION
```
*** Downloading binary-only framework Crashlytics at "https://raw.githubusercontent.com/torufuruya/Specs/master/Carthage/iOS/Crashlytics.json"
*** Downloading Crashlytics.framework binary at "3.10.8"
*** Downloading binary-only framework Fabric at "https://raw.githubusercontent.com/torufuruya/Specs/master/Carthage/iOS/Fabric.json"
*** Downloading Fabric.framework binary at "1.7.12"
```