### PR TITLE
Update Answers to 1.4.0, Crashlytics to 3.11.0, and Fabric to 1.8.0

### DIFF
--- a/Carthage/iOS/Answers.json
+++ b/Carthage/iOS/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.4.0": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.4.0/com.twitter.answers.ios-default.zip",
   "1.3.7": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.7/com.twitter.answers.ios-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.6/com.twitter.answers.ios-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/ios/com.twitter.answers.ios/1.3.5/com.twitter.answers.ios-default.zip",

--- a/Carthage/iOS/Crashlytics.json
+++ b/Carthage/iOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.11.0": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.11.0/com.twitter.crashlytics.ios-default.zip",
   "3.10.9": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.9/com.twitter.crashlytics.ios-default.zip",
   "3.10.8": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.8/com.twitter.crashlytics.ios-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip",

--- a/Carthage/iOS/Fabric.json
+++ b/Carthage/iOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.8.0": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.8.0/io.fabric.sdk.ios-default.zip",
   "1.7.13": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.13/io.fabric.sdk.ios-default.zip",
   "1.7.12": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.12/io.fabric.sdk.ios-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.11/io.fabric.sdk.ios-default.zip",

--- a/Carthage/macOS/Answers.json
+++ b/Carthage/macOS/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.4.0": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.4.0/com.twitter.answers.mac-default.zip",
   "1.3.7": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.7/com.twitter.answers.mac-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.6/com.twitter.answers.mac-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/mac/com.twitter.answers.mac/1.3.5/com.twitter.answers.mac-default.zip",

--- a/Carthage/macOS/Crashlytics.json
+++ b/Carthage/macOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.11.0": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.11.0/com.twitter.crashlytics.mac-default.zip",
   "3.10.9": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.9/com.twitter.crashlytics.mac-default.zip",
   "3.10.8": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.8/com.twitter.crashlytics.mac-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.10.7/com.twitter.crashlytics.mac-default.zip",

--- a/Carthage/macOS/Fabric.json
+++ b/Carthage/macOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.8.0": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.8.0/io.fabric.sdk.mac-default.zip",
   "1.7.13": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.13/io.fabric.sdk.mac-default.zip",
   "1.7.12": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.12/io.fabric.sdk.mac-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/mac/io.fabric.sdk.mac/1.7.11/io.fabric.sdk.mac-default.zip",

--- a/Carthage/tvOS/Answers.json
+++ b/Carthage/tvOS/Answers.json
@@ -1,4 +1,5 @@
 {
+  "1.4.0": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.4.0/com.twitter.answers.tvos-default.zip",
   "1.3.7": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.7/com.twitter.answers.tvos-default.zip",
   "1.3.6": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.6/com.twitter.answers.tvos-default.zip",
   "1.3.5": "https://kit-downloads.fabric.io/tvos/com.twitter.answers.tvos/1.3.5/com.twitter.answers.tvos-default.zip",

--- a/Carthage/tvOS/Crashlytics.json
+++ b/Carthage/tvOS/Crashlytics.json
@@ -1,4 +1,5 @@
 {
+  "3.11.0": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.11.0/com.twitter.crashlytics.tvos-default.zip",
   "3.10.9": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.9/com.twitter.crashlytics.tvos-default.zip",
   "3.10.8": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.8/com.twitter.crashlytics.tvos-default.zip",
   "3.10.7": "https://kit-downloads.fabric.io/tvos/com.twitter.crashlytics.tvos/3.10.7/com.twitter.crashlytics.tvos-default.zip",

--- a/Carthage/tvOS/Fabric.json
+++ b/Carthage/tvOS/Fabric.json
@@ -1,4 +1,5 @@
 {
+  "1.8.0": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.8.0/io.fabric.sdk.tvos-default.zip",
   "1.7.13": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.13/io.fabric.sdk.tvos-default.zip",
   "1.7.12": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.12/io.fabric.sdk.tvos-default.zip",
   "1.7.11": "https://kit-downloads.fabric.io/tvos/io.fabric.sdk.tvos/1.7.11/io.fabric.sdk.tvos-default.zip",

--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ Website: [https://fabric.io/kits/ios/crashlytics](https://fabric.io/kits/ios/cra
 ## Contribute
 
 If you want to add a popular framework to this list or if you notice that one of the JSON files is outdated, feel free to drop me a [pull request](https://github.com/Building42/Specs/pulls) and I'll merge it in.
-


### PR DESCRIPTION
New updates to Answers, Crashlytics, and Fabric, all of which [add support for the new arm64e architecture on the iPhone XR, XS and XS Max](https://docs.fabric.io/apple/changelog.html).