### PR TITLE
Add Universal jsons containing links to zip archives with all platforms

### DIFF
--- a/Carthage/Universal/Answers.json
+++ b/Carthage/Universal/Answers.json
@@ -1,0 +1,7 @@
+{
+  "1.4.0": "https://kit-downloads.fabric.io/cocoapods/answers/1.4.0/answers.zip",
+  "1.3.7": "https://kit-downloads.fabric.io/cocoapods/answers/1.3.7/answers.zip",
+  "1.3.6": "https://kit-downloads.fabric.io/cocoapods/answers/1.3.6/answers.zip",
+  "1.3.5": "https://kit-downloads.fabric.io/cocoapods/answers/1.3.5/answers.zip",
+  "1.3.4": "https://kit-downloads.fabric.io/cocoapods/answers/1.3.4/answers.zip"
+}

--- a/Carthage/Universal/Crashlytics.json
+++ b/Carthage/Universal/Crashlytics.json
@@ -1,0 +1,19 @@
+{
+  "3.12.0": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.12.0/crashlytics.zip",
+  "3.11.1": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.11.1/crashlytics.zip",
+  "3.11.0": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.11.0/crashlytics.zip",
+  "3.10.9": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.9/crashlytics.zip",
+  "3.10.8": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.8/crashlytics.zip",
+  "3.10.7": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.7/crashlytics.zip",
+  "3.10.5": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.5/crashlytics.zip",
+  "3.10.4": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.4/crashlytics.zip",
+  "3.10.3": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.3/crashlytics.zip",
+  "3.10.2": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.2/crashlytics.zip",
+  "3.10.1": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.1/crashlytics.zip",
+  "3.10.0": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.10.0/crashlytics.zip",
+  "3.9.3": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.9.3/crashlytics.zip",
+  "3.9.0": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.9.0/crashlytics.zip",
+  "3.8.6": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.8.6/crashlytics.zip",
+  "3.8.5": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.8.5/crashlytics.zip",
+  "3.8.4": "https://kit-downloads.fabric.io/cocoapods/crashlytics/3.8.4/crashlytics.zip"
+}

--- a/Carthage/Universal/Fabric.json
+++ b/Carthage/Universal/Fabric.json
@@ -1,0 +1,20 @@
+{
+  "1.9.0": "https://kit-downloads.fabric.io/cocoapods/fabric/1.9.0/fabric.zip",
+  "1.8.2": "https://kit-downloads.fabric.io/cocoapods/fabric/1.8.2/fabric.zip",
+  "1.8.1": "https://kit-downloads.fabric.io/cocoapods/fabric/1.8.1/fabric.zip",
+  "1.8.0": "https://kit-downloads.fabric.io/cocoapods/fabric/1.8.0/fabric.zip",
+  "1.7.13": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.13/fabric.zip",
+  "1.7.12": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.12/fabric.zip",
+  "1.7.11": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.11/fabric.zip",
+  "1.7.9": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.9/fabric.zip",
+  "1.7.8": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.8/fabric.zip",
+  "1.7.7": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.7/fabric.zip",
+  "1.7.6": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.6/fabric.zip",
+  "1.7.5": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.5/fabric.zip",
+  "1.7.2": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.2/fabric.zip",
+  "1.7.1": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.1/fabric.zip",
+  "1.7.0": "https://kit-downloads.fabric.io/cocoapods/fabric/1.7.0/fabric.zip",
+  "1.6.13": "https://kit-downloads.fabric.io/cocoapods/fabric/1.6.13/fabric.zip",
+  "1.6.12": "https://kit-downloads.fabric.io/cocoapods/fabric/1.6.12/fabric.zip",
+  "1.6.11": "https://kit-downloads.fabric.io/cocoapods/fabric/1.6.11/fabric.zip"
+}

--- a/README.md
+++ b/README.md
@@ -11,20 +11,22 @@ Analytics engine that powers the Fabric platform (requires the Fabric framework)
 Website: [https://fabric.io/kits/ios/answers](https://fabric.io/kits/ios/answers)
 
 | Platform | Lines to add to your Cartfile |
-| -------- | -------- |
-| iOS      | `binary "https://building42.github.io/Specs/Carthage/iOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"` |
-| tvOS     | `binary "https://building42.github.io/Specs/Carthage/tvOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/tvOS/Fabric.json"` |
-| macOS    | `binary "https://building42.github.io/Specs/Carthage/macOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/macOS/Fabric.json"` |
+| --------- | -------- |
+| Universal | `binary "https://building42.github.io/Specs/Carthage/Universal/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/Universal/Fabric.json"` |
+| iOS       | `binary "https://building42.github.io/Specs/Carthage/iOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"` |
+| tvOS      | `binary "https://building42.github.io/Specs/Carthage/tvOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/tvOS/Fabric.json"` |
+| macOS     | `binary "https://building42.github.io/Specs/Carthage/macOS/Answers.json"`<br>`binary "https://building42.github.io/Specs/Carthage/macOS/Fabric.json"` |
 
 ### Crashlytics
 Powerful, yet lightweight crash reporting solution (requires the Fabric framework).<br>
 Website: [https://fabric.io/kits/ios/crashlytics](https://fabric.io/kits/ios/crashlytics)
 
 | Platform | Lines to add to your Cartfile |
-| -------- | -------- |
-| iOS      | `binary "https://building42.github.io/Specs/Carthage/iOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"` |
-| tvOS     | `binary "https://building42.github.io/Specs/Carthage/tvOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/tvOS/Fabric.json"` |
-| macOS    | `binary "https://building42.github.io/Specs/Carthage/macOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/macOS/Fabric.json"` |
+| --------- | -------- |
+| Universal | `binary "https://building42.github.io/Specs/Carthage/Universal/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/Universal/Fabric.json"` |
+| iOS       | `binary "https://building42.github.io/Specs/Carthage/iOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"` |
+| tvOS      | `binary "https://building42.github.io/Specs/Carthage/tvOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/tvOS/Fabric.json"` |
+| macOS     | `binary "https://building42.github.io/Specs/Carthage/macOS/Crashlytics.json"`<br>`binary "https://building42.github.io/Specs/Carthage/macOS/Fabric.json"` |
 
 ## Contribute
 


### PR DESCRIPTION
Per discussion in https://github.com/Building42/Specs/pull/13 this PR adds support for single json file per framework. Each linked zip file contains frameworks for all platforms (iOS, macOS, tvOS).